### PR TITLE
Removed extra parenthesis on SBGC_ANGLE_TO_DEGREE

### DIFF
--- a/libraries/SBGC_lib/include/SBGC_cmd_helpers.h
+++ b/libraries/SBGC_lib/include/SBGC_cmd_helpers.h
@@ -22,7 +22,7 @@
 
 // Conversions for angle in degrees to angle in SBGC 14bit representation, and back
 #define SBGC_DEGREE_TO_ANGLE(val) ((val)*SBGC_DEGREE_ANGLE_SCALE)
-#define SBGC_ANGLE_TO_DEGREE(val) ((val)*SBGC_ANGLE_DEGREE_SCALE))
+#define SBGC_ANGLE_TO_DEGREE(val) ((val)*SBGC_ANGLE_DEGREE_SCALE)
 // The same, optimized for integers
 #define SBGC_DEGREE_TO_ANGLE_INT(val) ((int32_t)(val)*SBGC_ANGLE_FULL_TURN/360)
 #define SBGC_DEGREE_01_TO_ANGLE_INT(val) ((int32_t)(val)*SBGC_ANGLE_FULL_TURN/3600)


### PR DESCRIPTION
caused a compiler error (at least on Arduino)